### PR TITLE
feat: добавил SecurityConfig - разграничил доступы к endpoint, добавил валидацию JWT Token

### DIFF
--- a/auth-service/src/main/java/aidyn/kelbetov/config/SecurityConfig.java
+++ b/auth-service/src/main/java/aidyn/kelbetov/config/SecurityConfig.java
@@ -1,0 +1,39 @@
+package aidyn.kelbetov.config;
+
+import aidyn.kelbetov.jwt.JwtAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtFilter;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtFilter) {
+        this.jwtFilter = jwtFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/users/register").permitAll()
+                        .requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN")
+                        .requestMatchers("/api/users/**").hasAnyAuthority("ROLE_STUDENT", "ROLE_ADMIN")
+                        .requestMatchers("/api/teachers/**").hasAnyAuthority("ROLE_TEACHER", "ROLE_ADMIN")
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/auth-service/src/main/java/aidyn/kelbetov/jwt/JwtAuthenticationFilter.java
+++ b/auth-service/src/main/java/aidyn/kelbetov/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package aidyn.kelbetov.jwt;
+
+import aidyn.kelbetov.model.Role;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider tokenProvider;
+
+
+    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+
+        if(authHeader != null && authHeader.startsWith("Bearer ")){
+            String token = authHeader.substring(7);
+
+            if(tokenProvider.validateToken(token)){
+                String email = tokenProvider.getEmailFromToken(token);
+                Role role = tokenProvider.getRoleFromToken(token);
+                UsernamePasswordAuthenticationToken auth =
+                        new UsernamePasswordAuthenticationToken(email, null, List.of(new SimpleGrantedAuthority(role.name())));
+
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/auth-service/src/main/java/aidyn/kelbetov/jwt/JwtTokenProvider.java
+++ b/auth-service/src/main/java/aidyn/kelbetov/jwt/JwtTokenProvider.java
@@ -1,6 +1,8 @@
 package aidyn.kelbetov.jwt;
 
 import aidyn.kelbetov.dto.UserDto;
+import aidyn.kelbetov.model.Role;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -24,11 +26,44 @@ public class JwtTokenProvider {
 
         return Jwts.builder()
                 .setSubject(user.getEmail())
-                .claim("role", user.getRole())
+                .claim("role", user.getRole().name())
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expiration))
                 .signWith(SignatureAlgorithm.HS256, secret)
                 .compact();
+    }
+
+    public String getEmailFromToken(String token){
+        return Jwts.parser()
+                .setSigningKey(secret)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public Role getRoleFromToken (String token){
+        String roleStr = Jwts.parser()
+                .setSigningKey(secret)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("role", String.class);
+
+        return Role.valueOf(roleStr);
+    }
+
+
+    public boolean validateToken(String token){
+        try {
+            Jwts.parser()
+                    .setSigningKey(secret)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException exception){
+            return false;
+        }
     }
 
 

--- a/auth-service/src/main/java/aidyn/kelbetov/service/impl/AuthServiceImpl.java
+++ b/auth-service/src/main/java/aidyn/kelbetov/service/impl/AuthServiceImpl.java
@@ -4,7 +4,6 @@ import aidyn.kelbetov.dto.AuthResponse;
 import aidyn.kelbetov.dto.LoginRequest;
 import aidyn.kelbetov.dto.UserDto;
 import aidyn.kelbetov.jwt.JwtTokenProvider;
-import aidyn.kelbetov.model.Role;
 import aidyn.kelbetov.service.AuthService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;


### PR DESCRIPTION
## Что сделано
- Реализован сервис авторизации (Auth-Service)
- Подключён JWT (с генерацией и валидацией токенов)
- Добавлен фильтр `JwtAuthenticationFilter` для защиты эндпоинтов
- Настроена `SecurityConfig` с ролями: ADMIN, STUDENT, TEACHER
- Настроены права доступа к эндпоинтам

## Проверка
- [x] Авторизация работает
- [x] Токен валиден
- [x] Доступ к защищённым эндпоинтам ограничен по ролям
